### PR TITLE
drop dead fonts URL

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,6 @@
  *= require_tree .
  *= require_self
  */
-$font-url: 'http://fonts.useso.com/css?family=Lato:400,700,400italic,700italic&subset=latin';
 @import "semantic-ui";
 @import 'datatables/jquery.dataTables';
 @import 'datatables/dataTables.semanticui';


### PR DESCRIPTION
A couple of things:
We deploy the site with HTTPS, so loading assets with HTTP doesn't work
in general. Also loading external content is a bad idea, it exposes
users data. Also the host is dead and returns NXDOMAIN.