### PR TITLE
use `merge-conflicts` instead of `needs-rebase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ At the moment, the application handles appearing and disappearing merge
 conflicts. Since
 [PR #35](https://github.com/voxpupuli/vox-pupuli-tasks/pull/35) went live, we
 are able to detect if a Pull request went from a mergeable into a non-mergeable
-state. In this case we check if the label `needs-rebase` is present in the
+state. In this case we check if the label `merge-conflicts` is present in the
 repository. Afterwards we add it to the pull request.
 
 [![bot adds label](images/bot_label.png)](https://voxpupu.li)

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -3,6 +3,6 @@ class Label < ApplicationRecord
 
   # TODO: Find out how to manage predefined labels
   def self.needs_rebase
-    find_or_create_by(name: 'needs-rebase', color: '207de5')
+    find_or_create_by(name: 'merge-conflicts', color: '207de5')
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -73,10 +73,10 @@ class PullRequest < ApplicationRecord
   end
 
   ##
-  #  if the PullRequest is mergeable we need to check if the 'needs-rebase' Label
+  #  if the PullRequest is mergeable we need to check if the 'merge-conflicts' Label
   #  is attached. If so, we need to remove it.
   #
-  #  If the PullRequest is not yet mergeable we need to attach the 'needs-rebase'
+  #  If the PullRequest is not yet mergeable we need to attach the 'merge-conflicts'
   #  Label. Therefore we also need to check if the Label exists on repository level.
   #
   # The saved_changes variable includes all the stuff that has changed.


### PR DESCRIPTION
`needs-rebase` might be added when something got merged to master that's
missing in a feature branch. `merge-conflicts` are actual git conflicts.
Those are detectable by this application. The color stays the same, as
bove labels are for the same topic.