### PR TITLE
improve webhook security

### DIFF
--- a/app/controllers/incoming_controller.rb
+++ b/app/controllers/incoming_controller.rb
@@ -22,10 +22,10 @@ class IncomingController < ApplicationController
     signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'),
                                                   webhook_secret,
                                                   payload)
-    if Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
-      Raven.capture_message('Valid webhook signature')
-    else
-      Raven.capture_message('Invalid webhook signature')
-    end
+
+    return if Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'])
+
+    Raven.capture_message('Invalid webhook signature')
+    halt 500, 'invalid signature'
   end
 end


### PR DESCRIPTION
Do not log if a valid request is registred and stop processing if an invalid one is seen.