### PR TITLE
RepoStatusWorker: explicitly return `data` in check_metadatas

### DIFF
--- a/app/workers/repo_status_worker.rb
+++ b/app/workers/repo_status_worker.rb
@@ -83,6 +83,7 @@ class RepoStatusWorker
       rescue NoMethodError
         data.modules_without_operatingsystems_support << repo
       end
+      data
     end
   end
 


### PR DESCRIPTION
this should fix:
```
NoMethodError: undefined method `supports_eol_centos' for #<Hash:0x0000560a8c259990>
```

this explicit return statement was already present...