### PR TITLE
Drop Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ index 14b0459..cc4f26e 100644
 +++ b/config/initializers/voxpupuli.rb
 @@ -16,6 +16,6 @@ PUPPET_SUPPORT_RANGE = '>= 5.5.8 < 7.0.0'
  # https://github.com/camptocamp/facterdb/pull/82#event-1600066178
- UBUNTU_SUPPORT_RANGE = ['14.04', '16.04', '18.04'].freeze
+ UBUNTU_SUPPORT_RANGE = ['16.04', '18.04'].freeze
  DEBIAN_SUPPORT_RANGE = [8, 9, 10].freeze
 -CENTOS_SUPPORT_RANGE = [6, 7].freeze
 +CENTOS_SUPPORT_RANGE = [6, 7, 8].freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
       description: We use 'operatingsystem_support' in the metadata.json to verify support ranges. It's missing in this modules.
     doesnt_support_latest_ubuntu:
       title: Does not support latest Ubuntu
-      description: We support Ubuntu 14.04, 16.04 and 18.04. Modules in here don't support Ubuntu 18.04.
+      description: We support Ubuntu 16.04 and 18.04. Modules in here don't support Ubuntu 18.04.
     doesnt_support_latest_freebsd:
       title: Does not support latest FreeBSD
       description: We support FreeBSD 11 and 12. Modules in here don't support FreeBSD 12.

--- a/config/voxpupuli.yml
+++ b/config/voxpupuli.yml
@@ -20,7 +20,6 @@ puppet_support_range: '>= 5.5.8 < 7.0.0'
 # https://github.com/camptocamp/facterdb/pull/82#event-1600066178
 support_ranges:
   ubuntu:
-    - '14.04'
     - '16.04'
     - '18.04'
   debian:
@@ -38,4 +37,4 @@ support_ranges:
     - 29
     - 30
     - 31
-    
+


### PR DESCRIPTION
Puppet Inc. started to deprecate modules with Ubuntu 14.04 so we should
drop it as well. For example: https://forge.puppet.com/puppetlabs/inifile/changelog#v400-2019-11-11