### PR TITLE
travis: switch Ruby 2.5.3->2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.5.3
+  - rvm: 2.6.3
     bundler_args: --without development --jobs "$(nproc)"
     env: CHECK=rubocop
 branches:


### PR DESCRIPTION
We switched the baseimage from 16.04 to 18.04. It now bundles 2.6.3 by
default. Other ruby versions need to be installed, which takes time.
Switching to 2.6.3 will speed up our travis runs.