### PR TITLE
handle labels

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -76,7 +76,9 @@ class Repository < ApplicationRecord
   def labels
     @labels ||= begin
       Github.client.labels("voxpupuli/#{name}").map do |label|
-        Label.find_or_create_by!(name: label[:name], color: label[:color], description: label[:description])
+        Label.find_or_create_by!(name: label[:name],
+                                 color: label[:color],
+                                 description: label[:description])
       end
     end
   end
@@ -117,19 +119,23 @@ class Repository < ApplicationRecord
   #
   def sync_label_colors_and_descriptions
     config_labels = VOXPUPULI_CONFIG['labels'].map do |label|
-      Label.new(name: label['name'], color: label['color'], description: label['description'])
+      Label.new(name: label['name'],
+                color: label['color'],
+                description: label['description'])
     end
 
     labels.each do |label|
-      config_label = config_labels.select{|c_label| c_label.name == label.name}.first
-
-      p config_label
-
+      config_label = config_labels.select { |c_label| c_label.name == label.name }.first
 
       next unless config_label
       next if (label.color == config_label.color) && (label.description == config_label.description)
 
-      Github.client.update_label(github_id, config_label.name, { color: config_label.color, description: config_label.description })
+      Github.client.update_label(github_id,
+                                 config_label.name,
+                                 {
+                                   color: config_label.color,
+                                   description: config_label.description
+                                 })
     end
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -70,6 +70,67 @@ class Repository < ApplicationRecord
   end
 
   ##
+  #  Fetch the Labels for this Repository from GitHub
+  #  and create it in our database
+  #
+  def labels
+    @labels ||= begin
+      Github.client.labels("voxpupuli/#{name}").map do |label|
+        Label.find_or_create_by!(name: label[:name], color: label[:color])
+      end
+    end
+  end
+
+  ##
+  #  Find all Labels which are in our config but are missing from the
+  #  Repository on GitHub
+  #
+  def missing_labels
+    required_label_names = VOXPUPULI_CONFIG['labels'].map do |label|
+      label['name']
+    end
+
+    label_names = labels.pluck(:name)
+
+    missing_label_names = required_label_names.reject do |name|
+      label_names.include?(name)
+    end
+
+    missing_label_names.map do |name|
+      Label.find_by(name: name)
+    end
+  end
+
+  ##
+  #  Create each missing Label for the repository on GitHub
+  #
+  def attach_missing_labels
+    missing_labels.each do |label|
+      ensure_label_exists(label)
+    end
+  end
+
+  ##
+  #  Compare the Labels on GitHub with the ones from our config
+  #  If we have the Label in our config but the color differs
+  #  we update the Label on GitHub to match the config.
+  #
+  def sync_label_colors
+    config_labels = VOXPUPULI_CONFIG['labels'].map do |label|
+      Label.new(name: label['name'], color: label['color'])
+    end
+
+    labels.each do |label|
+      config_label = config_labels.select{|c_label| c_label.name == label.name}.first
+
+      next unless config_label
+      next if label.color == config_label.color
+
+      Github.client.update_label(github_id, config_label.name, { color: config_label.color })
+    end
+  end
+
+  ##
   #  Fetch all open and closed PullRequests and sync our database with them
   #
   def update_pull_requests(only_open: false)

--- a/app/workers/index_repos_worker.rb
+++ b/app/workers/index_repos_worker.rb
@@ -23,5 +23,6 @@ class IndexReposWorker
     end
 
     RepoStatusWorker.perform_async
+    SyncLabelWorker.perform_async
   end
 end

--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -6,6 +6,6 @@ class SyncLabelWorker
   def perform
     Repository.each do |repository|
       repository.attach_missing_labels
-      repository.sync_label_colors
+      repository.sync_label_colors_and_descriptions
     end
 end

--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -6,5 +6,6 @@ class SyncLabelWorker
   def perform
     Repository.each do |repository|
       repository.attach_missing_labels
+      repository.sync_label_colors
     end
 end

--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SyncLabelWorker
+  include Sidekiq::Worker
+
+  def perform
+    Repository.each do |repository|
+      repository.attach_missing_labels
+    end
+end

--- a/app/workers/sync_label_worker.rb
+++ b/app/workers/sync_label_worker.rb
@@ -8,4 +8,5 @@ class SyncLabelWorker
       repository.attach_missing_labels
       repository.sync_label_colors_and_descriptions
     end
+  end
 end

--- a/db/migrate/20200426200729_add_description_to_labels.rb
+++ b/db/migrate/20200426200729_add_description_to_labels.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToLabels < ActiveRecord::Migration[6.0]
+  def change
+    add_column :labels, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_24_091954) do
+ActiveRecord::Schema.define(version: 2020_04_26_200729) do
 
   create_table "labels", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_08_24_091954) do
     t.integer "pull_request_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description"
     t.index ["pull_request_id"], name: "index_labels_on_pull_request_id"
   end
 


### PR DESCRIPTION
Create methods to find missing Labels on our Repositories

Add a worker which is triggered with every IndexReposWorker run
to ensure we have all the Labels from our config in our Repositories
on GitHub

This tackles https://github.com/voxpupuli/vox-pupuli-tasks/issues/131

Signed-off-by: Flipez <code@brauser.io>