### PR TITLE
Add `irb` to development gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :development do
   gem 'foreman'
   gem 'haml-lint'
+  gem 'irb'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pry-rails'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,10 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.6)
     io-like (0.3.1)
+    irb (1.2.3)
+      reline (>= 0.0.1)
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
@@ -310,6 +313,8 @@ GEM
     redcarpet (3.5.0)
     redis (4.1.3)
     regexp_parser (1.7.0)
+    reline (0.1.4)
+      io-console (~> 0.5)
     request_store (1.5.0)
       rack (>= 1.4)
     rexml (3.2.4)
@@ -433,6 +438,7 @@ DEPENDENCIES
   groupdate
   haml-lint
   haml-rails
+  irb
   jbuilder (~> 2.5)
   jquery-datatables
   jquery-rails


### PR DESCRIPTION
Arch, for reasons that no-one can explain, does not ship irb in their
ruby package. Everything else relies on it. To use it properly, we need
to install it via Gemfile.