### PR TITLE
Dont validate a queued PR twice

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -153,9 +153,7 @@ class PullRequest < ApplicationRecord
     elsif mergeable.nil?
       UpdateMergeableWorker.perform_in(1.minute.from_now,
                                        repository.name,
-                                       number,
-                                       id,
-                                       saved_changes)
+                                       number)
     end
   end
 

--- a/app/workers/update_mergeable.rb
+++ b/app/workers/update_mergeable.rb
@@ -3,9 +3,8 @@
 class UpdateMergeableWorker
   include Sidekiq::Worker
 
-  def perform(repo, number, id, saved_changes)
+  def perform(repo, number)
     pull_request = Github.client.pull_request("voxpupuli/#{repo}", number)
     PullRequest.update_with_github(pull_request)
-    ValidatePullRequestWorker.perform_async(id, saved_changes)
   end
 end


### PR DESCRIPTION
If a PR comes in and has no `mergeable` attribute, we put a job into our
queue for a minute. Afterwards we checked the PR status twice. This
isn't required. This patch removed the duplicate check.