### PR TITLE
Save CI status as PR attribute

### DIFF
--- a/db/migrate/20200501212046_add_status_to_pull_requests.rb
+++ b/db/migrate/20200501212046_add_status_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddMergeableAndGhRepoIdToPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :status, :string, :default => "success"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_212046) do
     t.integer "github_id"
     t.string "author"
     t.boolean "eligible_for_comment"
+    t.string "status", :default => "success"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 


### PR DESCRIPTION
This will be a series of PRs:
* Save combined CI status as pull_request attribute
* Use that to validate if we should a comment/label about CI failures
* Not only set label/comment if CI is broken, but if the state changes (use saved_changes)
