### PR TITLE
pull_request: save draft state

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -44,6 +44,7 @@ class PullRequest < ApplicationRecord
       pull_request.mergeable        = gh_pull_request['mergeable']
       pull_request.author           = gh_pull_request['user']['login']
       pull_request.status           = status
+      pull_request.draft            = gh_pull_request['draft']
       pull_request.save
 
       gh_pull_request['labels'].each do |label|
@@ -160,6 +161,9 @@ class PullRequest < ApplicationRecord
   def validate(saved_changes)
     # Don't run through the validaten, if only the eligible_for_comment attribute got updated
     return if saved_changes.keys.sort == %w[updated_at eligible_for_comment].sort && !mergeable.nil?
+
+    # Don't run through validation if it's a draft
+    return if draft
 
     # if the pull request is now closed, dont attach/remove labels/comments
     return if closed?

--- a/db/migrate/20200502213446_add_draft_to_pull_requests.rb
+++ b/db/migrate/20200502213446_add_draft_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddDraftToPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :draft, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_212046) do
     t.string "author"
     t.boolean "eligible_for_comment"
     t.string "status", :default => "success"
+    t.boolean "draft", :default => false
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 


### PR DESCRIPTION
We should not label/comment on a draft PR. To detect this, we should
save the state.