### PR TITLE
Rename eligible_for_{,merge}comment / Prevent duplicate CI comments

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -115,6 +115,27 @@ class PullRequest < ApplicationRecord
   end
 
   ##
+  # Only attach a comment if eligible_for_merge_comment is true (The first iteration
+  # after the mergeable state changed to false)
+  def add_merge_comment
+    return unless eligible_for_merge_comment
+
+    add_comment(I18n.t('comment.needs_rebase', author: author))
+    update(eligible_for_merge_comment: false)
+  end
+
+  ##
+  # Only attach a comment if eligible_for_ci_comment is true (if CI was okay and changed to fail)
+  # This logic is required to prevent comments for failure -> pending -> failure
+  # Also it prevents duplicate comments
+  def add_ci_comment
+    return unless eligible_for_ci_comment
+
+    add_comment(I18n.t('comment.tests_fail', author: author))
+    update(eligible_for_ci_comment: false)
+  end
+
+  ##
   #  Add a comment with the given text
   def add_comment(text)
     # TODO: why can request be nil and what is request
@@ -123,9 +144,6 @@ class PullRequest < ApplicationRecord
           rescue StandardError
             nil
           end
-    # Only attach a comment if eligible_for_merge_comment is true (The first iteration
-    # after the mergeable state changed to false)
-    return unless eligible_for_merge_comment
 
     Raven.capture_message('Added a comment',
                           extra: { text: text,
@@ -133,7 +151,6 @@ class PullRequest < ApplicationRecord
                                    title: title,
                                    request: req })
     Github.client.add_comment(gh_repository_id, number, text)
-    update(eligible_for_merge_comment: false)
   end
 
   ##
@@ -147,17 +164,20 @@ class PullRequest < ApplicationRecord
   # We currently don't care about them
 
   def validate(saved_changes)
-    # Don't run through the validaten, if only the eligible_for_merge_comment attribute got updated
-    return if saved_changes.keys.sort == %w[updated_at eligible_for_merge_comment].sort && !mergeable.nil?
-
     # Don't run through validation if it's a draft
     return if draft
 
     # if the pull request is now closed, dont attach/remove labels/comments
     return if closed?
 
-    # check merge status and do work if required
-    validate_mergeable
+    # Don't run through the validaten, if only the eligible_for_merge_comment attribute got updated
+    if saved_changes.keys.sort != %w[updated_at eligible_for_merge_comment].sort && mergeable.nil?
+      # check merge status and do work if required
+      validate_mergeable
+    end
+
+    # Don't run through the validaten, if only the eligible_for_ci_comment attribute got updated
+    return unless saved_changes.keys.sort != %w[updated_at eligible_for_ci_comment].sort
 
     # check CI status and do work if required
     validate_status(saved_changes)
@@ -184,7 +204,7 @@ class PullRequest < ApplicationRecord
       ##
       # We only add a comment if we added a label. If the label already is present
       # we also already added the comment. So no need for a new one.
-      add_comment(I18n.t('comment.needs_rebase', author: author)) if ensure_label_is_attached(label)
+      add_merge_comment if ensure_label_is_attached(label)
     elsif mergeable.nil?
       UpdateMergeableWorker.perform_in(1.minute.from_now,
                                        repository.name,
@@ -199,15 +219,15 @@ class PullRequest < ApplicationRecord
     when 'failure'
       # if CI failed, add a label to repo
       repository.ensure_label_exists(label)
-      # if CI failed AND was green, add a new comment
-      # TODO: Check if it was `success` previously / Check what it was before it was `pending`
+      # A status change is required for a new comment
       return unless saved_changes.keys.sort.include?('status')
 
-      add_comment(I18n.t('comment.tests_fail', author: author)) if ensure_label_is_attached(label)
+      add_ci_comment if ensure_label_is_attached(label)
     when 'success'
       ensure_label_is_detached(label)
+      update(eligible_for_ci_comment: true)
     when 'pending'
-      # recheck in 10min? do get get an event if the status changes?
+      # recheck in 10min? do we get an event if the status changes?
       true
     else
       Raven.capture_message('Unknown PR state /o\\',

--- a/db/migrate/20200502221147_fix_column_name.rb
+++ b/db/migrate/20200502221147_fix_column_name.rb
@@ -1,0 +1,5 @@
+class FixColumnName < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :pull_requests, :eligible_for_comment, :eligible_for_merge_comment
+  end
+end

--- a/db/migrate/20200502221148_add_eligible_for_ci_comment.rb
+++ b/db/migrate/20200502221148_add_eligible_for_ci_comment.rb
@@ -1,0 +1,5 @@
+class AddEligibleForCiComment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :eligible_for_ci_comment, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_212046) do
     t.integer "gh_repository_id"
     t.integer "github_id"
     t.string "author"
-    t.boolean "eligible_for_comment", default: true
+    t.boolean "eligible_for_merge_comment", default: true
     t.string "status", :default => "success"
     t.boolean "draft", :default => false
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"


### PR DESCRIPTION
Depends on https://github.com/voxpupuli/vox-pupuli-tasks/pull/165 / should be rebased after that's merged.