### PR TITLE
Add missing attribute to schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_29_212046) do
     t.integer "github_id"
     t.string "author"
     t.boolean "eligible_for_merge_comment", default: true
+    t.boolean "eligible_for_ci_comment", default: true
     t.string "status", :default => "success"
     t.boolean "draft", :default => false
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"


### PR DESCRIPTION
This attribute was already added in a migration, but not to the
schema.rb