### PR TITLE
Ignore postres-data directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ Dockerfile
 /tmp/
 /public/packs/
 /redis
+/postgres-data/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-debug.log*
 /redis
 
 .DS_store
+/postgres-data


### PR DESCRIPTION
In case people use the docker-compose file in this directory without
moving it, docker creates a postgres-data subdir. That won't be
accessible from the local user and therefore breaks git commands but
also docker build.