### PR TITLE
Cleanup dev/prod database setup

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,27 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-development:
   adapter: postgresql
   encoding: unicode
   database: vpt
   pool: 5
   username: vpt
   password: vptpgpassword
+  port: 5432
   host: localhost
-  port: 5555
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+# Do not use the same db as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+
+development:
+  <<: *default
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  host: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: vpt-redis
     volumes:
       - ./redis:/data
+    ports:
+      - 127.0.0.1:6379:6379
   web:
     restart: always
     image: voxpupuli/vox-pupuli-tasks
@@ -52,4 +54,5 @@ services:
       POSTGRES_USER: vpt
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
-      - ./db/production.sqlite3:/vpt/db/production.sqlite3
+    ports:
+      - 127.0.0.1:5432:5432


### PR DESCRIPTION
The idea is that development/test run locally without docker, but
connect to the postgres instance provided via docker-compose. Our
production setup runs in a container and connects via docker network to
postgres.