### PR TITLE
Add Uniq constraint to github_id

### DIFF
--- a/db/migrate/20200723172636_add_uniq_index_to_pull_request.rb
+++ b/db/migrate/20200723172636_add_uniq_index_to_pull_request.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexToPullRequest < ActiveRecord::Migration[6.0]
+  def change
+    add_index :pull_requests, :github_id, unique: true
+  end
+end

--- a/db/migrate/20200723173538_add_uniq_index_to_repository2.rb
+++ b/db/migrate/20200723173538_add_uniq_index_to_repository2.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexToRepository2 < ActiveRecord::Migration[6.0]
+  def change
+    add_index :repositories, :github_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_03_192132) do
+ActiveRecord::Schema.define(version: 2020_07_23_173538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_192132) do
     t.string "status"
     t.boolean "draft", default: false
     t.boolean "eligible_for_ci_comment", default: true
+    t.index ["github_id"], name: "index_pull_requests_on_github_id", unique: true
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 
@@ -65,6 +66,7 @@ ActiveRecord::Schema.define(version: 2020_05_03_192132) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "todos", default: {}
+    t.index ["github_id"], name: "index_repositories_on_github_id", unique: true
     t.index ["name"], name: "index_repositories_on_name", unique: true
   end
 


### PR DESCRIPTION
tested this locally:

```
$ bundle exec rake db:migrate
I, [2020-07-23T19:40:16.210780 #55735]  INFO -- sentry: ** [Raven] Raven 2.13.0 configured not to capture errors: DSN not set
DEPRECATION WARNING: Single arity template handlers are deprecated. Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Coffee::Rails::TemplateHandler.call(template)
To:
  >> Coffee::Rails::TemplateHandler.call(template, source)
 (called from <top (required)> at /home/bastelfreak/vox-pupuli-tasks/Rakefile:8)
== 20200723172636 AddUniqIndexToPullRequest: migrating ========================
-- add_index(:pull_requests, :github_id, {:unique=>true})
   -> 0.0229s
== 20200723172636 AddUniqIndexToPullRequest: migrated (0.0230s) ===============

== 20200723173538 AddUniqIndexToRepository2: migrating ========================
-- add_index(:repositories, :github_id, {:unique=>true})
   -> 0.0127s
== 20200723173538 AddUniqIndexToRepository2: migrated (0.0128s) ===============
```