### PR TITLE
(#213) queue PR update if status is `pending`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,7 @@ Metrics/ClassLength:
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 10
+  Max: 11
 
 # Offense count: 15
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.
@@ -40,7 +40,7 @@ Metrics/ParameterLists:
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 9
 
 # Offense count: 2
 # Configuration parameters: Include.


### PR DESCRIPTION
the status is pending if one configured check is still running. If a PR
was just created, the checks haven't passed/failed yet. This wouldn't be
bad IF we would get notifications if they finish. This superseeds
https://github.com/voxpupuli/vox-pupuli-tasks/pull/214