### PR TITLE
Sidekiq: Set concurrency to 1

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,4 @@
+:concurrency: 1
 :logfile: log/sidekiq.log
 :max_retries: 0
 :schedule:


### PR DESCRIPTION
To avoid multiple concurrent jobs that might conflict, we set the
concurrency to 1.

Stolen from
https://github.com/mperham/sidekiq/wiki/Advanced-Options#the-sidekiq-configuration-file
/ https://github.com/voxpupuli/puppet_webhook/pull/156