### PR TITLE
Fix docker releases via GitHub actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake rubocop
     - name: Build and push Docker images
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -52,7 +52,7 @@ jobs:
         tag_with_ref: true
         tag_with_sha: true
     - name: Build and push Docker images
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
tl;dr v1 is broken and poorly documented. We raised those concerns via
an issue. That should be fixed in v2: https://github.com/docker/build-push-action/issues/88#event-3748118416