### PR TITLE
Queue a PR refresh if CI status is pending

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/BlockLength:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 136
+  Max: 137
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -227,6 +227,7 @@ class PullRequest < ApplicationRecord
       ensure_label_is_detached(label)
       update(eligible_for_ci_comment: true)
     when 'pending'
+      RefreshPullRequestWorker.perform_in(5.minutes.from_now, repository.name, number)
       Raven.capture_message('pending PR status', extra: { state: state, status: status, repo: repository.github_url, title: title })
       true
     when nil


### PR DESCRIPTION
This is a rebase of https://github.com/voxpupuli/vox-pupuli-tasks/pull/214
The original commit message:

---

the status is pending if one configured check is still running. If a PR
was just created, the checks haven't passed/failed yet. This wouldn't be
bad IF we would get notifications if they finish. We could implement
travis CI notification parsing for this, but people might implement
other checks as well. We can simply queue a job that updates the PR.

This fixes https://github.com/voxpupuli/vox-pupuli-tasks/issues/213 in parts. If we update the PR and the status is still
pending, we don't queue another job. After some thoughts it's probably a
good idea to move the logic from validate_status() to
`queue_validation()` and `validate()`.
