### PR TITLE
Compare heterogenous arrays via tally()

### DIFF
--- a/app/workers/validate_pull_request_worker.rb
+++ b/app/workers/validate_pull_request_worker.rb
@@ -8,9 +8,12 @@ class ValidatePullRequestWorker
       binding.local_variable_get(name)
     end
 
+    this_args = this_args.tally.to_a
     queue = Sidekiq::Queue.new('default')
     queue.each do |job|
-      if (job.args.sort == this_args.sort) && (job.item['class'] == name)
+      # use tally. the arrays can contain strings and ints. we cannot call sort on heterogenous arrays
+      # see also https://twitter.com/BastelsBlog/status/1311421975827546112
+      if (job.args.tally.to_a - this_args).empty? && (job.item['class'] == name)
         Raven.capture_message('Duplicate Job, discarding', extra: { id: id, worker: name })
         return false
       end


### PR DESCRIPTION
In the past we compared arrays by sorting & comparing them:
```
array1.sort == array2.sort
```

rubys array comparsion is order dependent:
```
irb(main):015:0> [1, 2] == [2, 1]
=> false
```

that's why we usually sort them first. But we cannot sort heterogenous
arrays:
```
irb(main):032:0> ["puppet-firewalld", 299].sort
Traceback (most recent call last):
        2: from (irb):32
        1: from (irb):32:in `sort'
ArgumentError (comparison of String with 299 failed)
irb(main):033:0>
```

`tally()` got introduced in Ruby 2.7 and counts the occurences of all
elements:

```
irb(main):029:0> ['1', 2].tally
=> {"1"=>1, 2=>1}
```

This means we can call `tally()` on both arrays, convert the return
value to an array and create a new set and check if that's empty:

```
irb(main):030:0> ['1', 2].tally.to_a - [2, '1'].tally.to_a
=> []
irb(main):031:0> ['1', 2, 2].tally.to_a - [2, '1'].tally.to_a
=> [[2, 2]]
```

site note: We cannot create a simple set with our base arrays. This will
fail if a value occurs multiple times in one array (check the last
command, the second `2` in the first array got lost):

```
irb(main):023:0> ['1', 2] - [2, '1']
=> []
irb(main):024:0> ['1', 2, 3] - [2, '1']
=> [3]
irb(main):025:0> ['1', 2, 2] - [2, '1']
=> []
```