### PR TITLE
Update supported puppet versions to `>=6.1.0 < 8.0.0`

### DIFF
--- a/config/voxpupuli.yml
+++ b/config/voxpupuli.yml
@@ -16,7 +16,7 @@ legacy_or_broken_nobody_knows:
   - puppet-mode
 
 # define some versions that we want to match against
-puppet_support_range: ">= 5.5.8 < 7.0.0"
+puppet_support_range: ">= 6.1.0 < 8.0.0"
 
 # Updates here probably also need an update here: config/locales/*.yml
 support_ranges:


### PR DESCRIPTION
Puppet 5 is now end of life and Puppet 7 got released some time ago.