### PR TITLE
mimemagic: Update 0.3.5->0.3.10 

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -19,10 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
     - uses: actions/cache@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitar (0.9)


### PR DESCRIPTION
The used version 0.3.5 got pulled from rubygems so we cannot install the
application anymore. Instead of updating all gems, which would require
more testing, we only update mimemagic for now.

This PR also contains https://github.com/voxpupuli/vox-pupuli-tasks/pull/262