### PR TITLE
Gemfile: drop legacy travis gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,6 @@ group :development do
   gem 'pry-rails'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'travis'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    backports (3.18.2)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -108,8 +107,6 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.4)
       tzinfo
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
     execjs (2.7.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
@@ -134,13 +131,6 @@ GEM
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2, < 3.3.0)
       locale
-    gh (0.15.1)
-      addressable (~> 2.4.0)
-      backports
-      faraday (~> 0.8)
-      multi_json (~> 1.0)
-      net-http-persistent (~> 2.9)
-      net-http-pipeline
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     groupdate (5.2.1)
@@ -163,7 +153,6 @@ GEM
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
     hashie (4.1.0)
-    highline (1.7.10)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -182,7 +171,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.3.1)
     jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
@@ -196,8 +184,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -223,8 +209,6 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
-    net-http-persistent (2.9.4)
-    net-http-pipeline (1.0.1)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
@@ -292,9 +276,6 @@ GEM
       gettext-setup (~> 0.11)
       minitar
       semantic_puppet (~> 1.0)
-    pusher-client (0.6.2)
-      json
-      websocket (~> 1.0)
     raabro (1.3.3)
     racc (1.5.2)
     rack-protection (2.1.0)
@@ -433,23 +414,11 @@ GEM
     thwait (0.2.0)
       e2mmap
     tilt (2.0.10)
-    travis (1.8.13)
-      backports
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9, >= 0.9.1)
-      gh (~> 0.13)
-      highline (~> 1.6)
-      launchy (~> 2.1)
-      pusher-client (~> 0.4)
-      typhoeus (~> 0.6, >= 0.6.8)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
-    websocket (1.2.8)
     websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -510,7 +479,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
-  travis
   uglifier (>= 1.3.0)
 
 BUNDLED WITH


### PR DESCRIPTION
We don't need it since we migrated to github actions.