### PR TITLE
Improve Operating System support stats

### DIFF
--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -12,7 +12,7 @@
 .ui.five.cards
   - ['Ubuntu', 'Debian', 'CentOS', 'FreeBSD', 'Fedora'].each do |os|
     .ui.card
-      - relevent_status_count = @statuses.count { |rs| !rs.checks["supports_only_current_#{os.downcase}"].nil? }
+      - relevant_status_count = @statuses.count { |rs| !rs.checks["supports_only_current_#{os.downcase}"].nil? }
       .content
         .ui.large.header= os
       .content
@@ -21,10 +21,10 @@
           Does not support EOL
           %span{data: { tooltip: I18n.t("check_descriptions.supports_only_current", os: os, versions: "#{os.upcase}_SUPPORT_RANGE".constantize.to_sentence), position: 'top center'}}
             %i.icon.question.mark.circle.outline
-        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevent_status_count)}= pass_count
+        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevant_status_count)}= pass_count
         %span.ui.big.grey.text{style: 'padding-left: 5px;'}
           \/
-          = relevent_status_count
+          = relevant_status_count
 
       .content
         - pass_count = @statuses.count{|rs| rs.checks["supports_latest_#{os.downcase}"]}
@@ -32,10 +32,10 @@
           Supports latest
           %span{data: { tooltip: I18n.t("check_descriptions.supports_latest", os: os, version: "#{os.upcase}_SUPPORT_RANGE".constantize.last), position: 'top center'}}
             %i.icon.question.mark.circle.outline
-        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevent_status_count)}= pass_count
+        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevant_status_count)}= pass_count
         %span.ui.big.grey.text{style: 'padding-left: 5px;'}
           \/
-          = relevent_status_count
+          = relevant_status_count
 
 .ui.large.header Plumbing and Syncing
 .ui.four.cards

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -12,6 +12,7 @@
 .ui.five.cards
   - ['Ubuntu', 'Debian', 'CentOS', 'FreeBSD', 'Fedora'].each do |os|
     .ui.card
+      - relevent_status_count = @statuses.count { |rs| !rs.checks["supports_only_current_#{os.downcase}"].nil? }
       .content
         .ui.large.header= os
       .content
@@ -20,10 +21,10 @@
           Does not support EOL
           %span{data: { tooltip: I18n.t("check_descriptions.supports_only_current", os: os, versions: "#{os.upcase}_SUPPORT_RANGE".constantize.to_sentence), position: 'top center'}}
             %i.icon.question.mark.circle.outline
-        %span.ui.huge.text{class: color_by_passed_checks(pass_count, @statuses.count)}= pass_count
+        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevent_status_count)}= pass_count
         %span.ui.big.grey.text{style: 'padding-left: 5px;'}
           \/
-          = @statuses.count
+          = relevent_status_count
 
       .content
         - pass_count = @statuses.count{|rs| rs.checks["supports_latest_#{os.downcase}"]}
@@ -31,10 +32,10 @@
           Supports latest
           %span{data: { tooltip: I18n.t("check_descriptions.supports_latest", os: os, version: "#{os.upcase}_SUPPORT_RANGE".constantize.last), position: 'top center'}}
             %i.icon.question.mark.circle.outline
-        %span.ui.huge.text{class: color_by_passed_checks(pass_count, @statuses.count)}= pass_count
+        %span.ui.huge.text{class: color_by_passed_checks(pass_count, relevent_status_count)}= pass_count
         %span.ui.big.grey.text{style: 'padding-left: 5px;'}
           \/
-          = @statuses.count
+          = relevent_status_count
 
 .ui.large.header Plumbing and Syncing
 .ui.four.cards


### PR DESCRIPTION
All modules do not support all operating systems.

The #check_operating_system_support method iterates on each supported
operating system and set `supports_only_current_<os>` and
`supports_latest_<os>` accordingly.  We can therefore check if a value
was registered or not for them, i.e. true and false vs. nil.

Each OS will then display the number of up-to-date modules compared to
the number of modules which idealy should be up-to-date, and not
compared to all existing modules.
